### PR TITLE
Use the latest docker version in alpine-based images.

### DIFF
--- a/dockerfiles/alpine-docker/Dockerfile
+++ b/dockerfiles/alpine-docker/Dockerfile
@@ -4,4 +4,4 @@
 
 FROM alpine:latest
 
-RUN apk update && apk add docker
+RUN sed -i 's/v3.10/latest-stable/g' /etc/apk/repositories && apk update && apk add docker

--- a/dockerfiles/alpine-supervisord-docker/Dockerfile
+++ b/dockerfiles/alpine-supervisord-docker/Dockerfile
@@ -9,7 +9,9 @@
 FROM alpine:latest
 
 # docker
-RUN apk add --update docker && rm  -rf /tmp/* /var/cache/apk/*
+RUN sed -i 's/v3.10/latest-stable/g' /etc/apk/repositories && \
+    apk add --update docker && \
+    rm  -rf /tmp/* /var/cache/apk/*
 
 # supervisord
 RUN apk add --update supervisor && rm  -rf /tmp/* /var/cache/apk/*


### PR DESCRIPTION
When using alpine latest + Docker 18.09.8-ce, the "docker pull"
command sometimes fails with an error such as:

"failed to register layer: Error processing tar file(exit status 1): operation not permitted"

By updating Docker to version 19.03 the problem goes away, suggesting
that the cause is some incompatibility between the docker 18.09
and the alpine-based libraries.